### PR TITLE
Fix deprecation warning surfacing in hera CI (refs hera#971)

### DIFF
--- a/argos/utils/logging/helpers.py
+++ b/argos/utils/logging/helpers.py
@@ -11,7 +11,7 @@ import logging
 import logging.config
 import os.path
 import pathlib
-from importlib.resources import read_text
+from importlib.resources import files
 from typing import List
 
 #: Custom log level between DEBUG (10) and INFO (20), used for
@@ -132,7 +132,7 @@ def get_default_logging_config(*, disable_existing_loggers: bool = False) -> dic
     """
     defaultLocalConfig = os.path.join(ARGOS_DEFAULT_LOG_DIR, 'argosLogging.config')
     if not os.path.isfile(defaultLocalConfig):
-        defaultConfig = read_text('argos.utils.logging', 'argosLogging.config')
+        defaultConfig = files('argos.utils.logging').joinpath('argosLogging.config').read_text()
         with open(defaultLocalConfig,'w') as localConfig:
             localConfig.write(defaultConfig)
 


### PR DESCRIPTION
## Summary
Fixes a DeprecationWarning that surfaces in hera's CI test output (hera clones this repo into `_vendor/pyargos`):

- `argos/utils/logging/helpers.py`: replaced deprecated `importlib.resources.read_text` with `files().joinpath().read_text()`.

Refs KaplanOpenSource/hera#971

## Test plan
- [x] Compiled the file with `DeprecationWarning` promoted to an error — no warning
- [ ] Confirm hera's CI no longer reports this warning once this merges and hera's CI re-clones `_vendor/pyargos`

🤖 Generated with [Claude Code](https://claude.com/claude-code)